### PR TITLE
return selectAccount result instead of true

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ibmcloud-account",
 	"displayName": "IBM Cloud Account",
 	"description": "The IBM Cloud account extension for Visual Studio Code provides a single IBM Cloud sign-in experience for all other IBM extensions",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"engines": {
 		"vscode": "^1.38.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -300,8 +300,7 @@ async function selectAccountCommon() {
 
     // Select an account.
     try {
-        await cloudAccount.selectAccount(cb);
-        return true;
+        return await cloudAccount.selectAccount(cb);
     } catch (error) {
         vscode.window.showErrorMessage(error.message);
         return false;


### PR DESCRIPTION
When selectAccount ran without errors, we were always returning true.

This is not only a problem for downstream tools that assumed an account was indeed selected, but also for the end user, that would see the message `Selected IBM Cloud account undefined`.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>