### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Start Xvfb
         run: nohup Xvfb :99 -screen 0 1024x768x24 < /dev/null > /dev/null 2>&1 &
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 20
       - name: Install Visual Studio Code Extensions CLI
         run: npm install -g vsce
       - name: Install extension dependencies


### PR DESCRIPTION
The CI workflow was pinned to actions/checkout@v2 and actions/setup-node@v2, both of which run on a Node.js version GitHub has deprecated on its runners, and it's also targeting Node 12 for the extension build itself. old enough that GitHub now forces them onto a Node runtime they weren't built for (hence the deprecation warning). Bumped both to @v4, and bumped the extension's own build target from Node 12 (EOL years ago) to Node 20 to match.